### PR TITLE
Add docsify and sidebar to session notes 2018

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+notes2018.jscraftcamp.org

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,0 +1,6 @@
+- [art-technology](art-technology/)
+- [culture-ownership-and-inclusion-in-tech](culture-ownership-and-inclusion-in-tech/)
+- [programming-for-kids](programming-for-kids/)
+- [shader-fun](shader-fun/)
+- [tdd-universal-everywhere](tdd-universal-everywhere/)
+- [vuejs](vuejs/)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>JSCraftCamp 2019 session notes</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="Description">
+  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      loadSidebar: true,
+      name: 'notes2018',
+      repo: 'jscraftcamp/notes2018',
+      subMaxLevel: 2
+    }
+  </script>
+  <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a `CNAME` and all necessary files for docsify to the repo to prepare it for `notes2018.jscraftcamp.org` deployment.

I think I have set up the necessary options in GitHub for the deployment (custom domain name, master as gh-pages branch). @davelosert can you add the subdomain at the domain hoster and check if this works?

Thanks!