### PR TITLE
Fix sidebar and title

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>JSCraftCamp 2019 session notes</title>
+  <title>JSCraftCamp 2018 session notes</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="Description">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">


### PR DESCRIPTION
- The current site did not load the sidebar properly. This is most probably happening due to Jekyll being used as a default and not serving files starting with an underscore like `_sidebar.md`. There is a `.nojekyll` file now to prevent this.
- The title did not match the year of the notes. `index.html` was changed accordingly.

Looks like I missed that when copying the jscc19-sessions repository. Fixed it in https://github.com/jscraftcamp/notes2017/pull/6 as well.